### PR TITLE
Fix set_sound_alarm service parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ service: somneo.set_sound_alarm
 target:
   entity_id: switch.somneo_alarm0
 data:
-  source: sunny day
-  channel: 20
-  level: 30
+  source: wake-up
+  channel: forest birds
+  level: 10
 ```
 The source is `wake-up` for the wake-up sounds, `radio` for the FM radio of `off` for no sound. If the wake-up sound is selected, channel is one of the following sounds: `forest birds`, `summer birds`, `morning alps`, `yoga harmony`, `nepal bowls`, `summer lake` or `ocean waves`. If the radio is selected, channel has a value 1 till 5 (formatted as a string). The level should be between 1 and 25.
 

--- a/custom_components/somneo/__init__.py
+++ b/custom_components/somneo/__init__.py
@@ -175,7 +175,7 @@ class SomneoCoordinator(DataUpdateCoordinator[None]):
         """Adjust the light settings of an alarm."""
         async with self.state_lock:
             await self.hass.async_add_executor_job(
-                self.somneo.set_light_alarm,
+                self.set_light_alarm,
                 alarm,
                 curve, 
                 level, 
@@ -195,7 +195,7 @@ class SomneoCoordinator(DataUpdateCoordinator[None]):
         """Adjust the sound settings of an alarm."""
         async with self.state_lock:
             await self.hass.async_add_executor_job(
-                self.somneo.set_sound_alarm,
+                self.set_sound_alarm,
                 alarm, 
                 source, 
                 level, 


### PR DESCRIPTION
The `set_sound_alarm` service is currently broken and calling it with parameters following parameters: 
```
source: wake-up
channel: forest birds
level: 10
```
raises `KeyError: 10`. This is caused by [pysomneo defining the order of arguments](https://github.com/theneweinstein/pysomneo/blob/master/pysomneo/__init__.py#L196) in a different order than `async_set_sound_alarm` calling it (level and channel are in the opposite order).

This PR fixes the issue by setting `async_set_sound_alarm` to call `self.set_sound_alarm` instead of directly calling pysomneo function. `set_sound_alarm` avoids this issue by using keyworded arguments.

Additionally, the README example for `somneo.set_sound_alarm` had the wrong parameters so this fixes them too.

Tested on my hass setup and seems to be working fine.