### PR TITLE
Optional tls sessions

### DIFF
--- a/custom_components/somneo/__init__.py
+++ b/custom_components/somneo/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN, UNKNOWN, WEEKEND, WORKDAYS, TOMORROW, EVERYDAY
+from .const import DOMAIN, UNKNOWN, WEEKEND, WORKDAYS, TOMORROW, EVERYDAY, CONF_SESSION
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Setup the Somneo component."""
     host = entry.data[CONF_HOST]
     
-    coordinator = SomneoCoordinator(hass, host)
+    coordinator = SomneoCoordinator(hass, host, use_session=entry.data.get(CONF_SESSION, True))
     entry.async_on_unload(entry.add_update_listener(update_listener))
     
     await coordinator.async_config_entry_first_refresh()
@@ -59,9 +59,10 @@ class SomneoCoordinator(DataUpdateCoordinator[None]):
         self,
         hass: HomeAssistant,
         host: str,
+        use_session: bool,
     ) -> None:
         """Initialize Somneo client."""
-        self.somneo = Somneo(host)
+        self.somneo = Somneo(host, use_session=use_session)
         self.state_lock = asyncio.Lock()
 
         super().__init__(

--- a/custom_components/somneo/const.py
+++ b/custom_components/somneo/const.py
@@ -8,6 +8,7 @@ VERSION: Final = "0.3"
 DEFAULT_NAME: Final = "Somneo"
 
 CONF_SENS: Final = 'sensors'
+CONF_SESSION: Final = 'session'
 
 ALARM: Final = 'alarm'
 PW: Final = 'powerwake'

--- a/custom_components/somneo/translations/en.json
+++ b/custom_components/somneo/translations/en.json
@@ -6,7 +6,8 @@
         "description": "Set up the Philips Somneo integration.",
         "data": {
           "host": "Host",
-          "name" : "Name"
+          "name" : "Name",
+          "session": "Reuse TLS connections"
         }
       }
     }

--- a/custom_components/somneo/translations/nl.json
+++ b/custom_components/somneo/translations/nl.json
@@ -6,7 +6,8 @@
         "description": "Installeer de Philips Somneo integratie.",
         "data": {
           "host": "IP-adres",
-          "name" : "Naam"
+          "name" : "Naam",
+          "session": "Hergebruik TLS verbindingen"
         }
       }
     }


### PR DESCRIPTION
This is an attempt to add optional TLS session reuse to the Somneo integration. Hopefully that improves the behaviour with the timeouts seen in #13. 

Naturally, this relies on the PR in your pysomneo repository

I'm having some trouble making the check mark show its description though, so that needs to be fixed still.