### PR TITLE
switch.somneo_alarm5 fix

### DIFF
--- a/custom_components/somneo/translations/en.json
+++ b/custom_components/somneo/translations/en.json
@@ -367,6 +367,7 @@
         }
       },
       "alarm5": {
+        "name": "Alarm5",
         "state_attributes": {
           "hour": {
             "name": "Hour"


### PR DESCRIPTION
switch.somneo_alarm5 entity was missing because name Alarm5 was missing in english translation.