### PR TITLE
Bump pysomneo to allow empty dusk light theme to be added to config, this is the default when first connecting to a wake up light

### DIFF
--- a/custom_components/somneo/manifest.json
+++ b/custom_components/somneo/manifest.json
@@ -15,7 +15,7 @@
         "somneo"
     ],
     "requirements": [
-        "pysomneo==4.2.2"
+        "pysomneo==4.2.4"
     ],
     "ssdp": [
         {


### PR DESCRIPTION
Follow up of https://github.com/theneweinstein/pysomneo/pull/20. Could you take a look @theneweinstein ?