### PR TITLE
Update unique ID configuration check with host

### DIFF
--- a/custom_components/somneo/config_flow.py
+++ b/custom_components/somneo/config_flow.py
@@ -102,7 +102,7 @@ class SomneoConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors["base"] = str(ex)
                 else:
                     await self.async_set_unique_id(user_input["dev_info"]["serial"])
-                    self._abort_if_unique_id_configured()
+                    self._abort_if_unique_id_configured(updates={CONF_HOST: user_input[CONF_HOST]})
                     return self.async_create_entry(
                         title=user_input[CONF_NAME], data=user_input
                     )


### PR DESCRIPTION
This one-line change (hopefully) fixes issue #78 by allowing the integration to update the IP address of an existing entry during re-configuration, rather than aborting immediately when the serial number is found.

I apologize, but I haven't had the opportunity to test this live on my Home Assistant yet. However, I have validated the logic with both Claude and Gemini. While my Python experience is limited, the issue seems trivial enough that I am confident this solution should work.

@theneweinstein Could you please test and review this?